### PR TITLE
add conditional to Category, DecisionCode parameters

### DIFF
--- a/vendor/riskified_php_sdk/src/Riskified/DecisionNotification/Model/Notification.php
+++ b/vendor/riskified_php_sdk/src/Riskified/DecisionNotification/Model/Notification.php
@@ -100,10 +100,12 @@ class Notification {
         $this->oldStatus = $order->{'old_status'};
         $this->description = $order->{'description'};
 
-        if (array_key_exists('category', $order))
+        if (array_key_exists('category', $order)) {
             $this->category = $order->{'category'};
+        }
 
-        if (array_key_exists('decision_code', $order))
+        if (array_key_exists('decision_code', $order)) {
             $this->decisionCode = $order->{'decision_code'};
+        }
     }
 }

--- a/vendor/riskified_php_sdk/src/Riskified/DecisionNotification/Model/Notification.php
+++ b/vendor/riskified_php_sdk/src/Riskified/DecisionNotification/Model/Notification.php
@@ -99,7 +99,11 @@ class Notification {
         $this->status = $order->{'status'};
         $this->oldStatus = $order->{'old_status'};
         $this->description = $order->{'description'};
-        $this->category = $order->{'category'};
-        $this->decisionCode = $order->{'decision_code'};
+
+        if (array_key_exists('category', $order))
+            $this->category = $order->{'category'};
+
+        if (array_key_exists('decision_code', $order))
+            $this->decisionCode = $order->{'decision_code'};
     }
 }


### PR DESCRIPTION
Approve decisions don't have Category, DecisionCode parameters. This would cause an error in the merchant's logs for every approved decision. This refactor conditionally sets Category, DecisionCode only if those parameters exist in our decision request. 