### PR TITLE
TIS-420 Prevent loading multiple rows

### DIFF
--- a/app/code/Riskified/Decider/Api/Order.php
+++ b/app/code/Riskified/Decider/Api/Order.php
@@ -338,6 +338,7 @@ class Order
             return $this->_orderFactory->getCollection()
                 ->addFieldToFilter('entity_id', $order_id)
                 ->addFieldToFilter('increment_id', $increment_id)
+                ->setPageSize(1)
                 ->getFirstItem();
         }
 


### PR DESCRIPTION
To fetch order entity from database, we use magento collection with filters for `entity_id` (primary key) and `increment id` (magento public order number) - it's impossible to fetch more than one order for this combination.
Magento/AdobeCommerce (AC) has a validation to prevent adding two items to collections with same primary key (in this case it's `entity_id` from `sales_order` table)
The issue is related to additional left join added to 3rd party extension. When order has more than one order item, it's duplicating results in the collection.

Solution is to set `limit` for db query and fetch only one item.
